### PR TITLE
Show Task View on click & position exit menu better

### DIFF
--- a/src/VirtualDesktopNumber/UI/TrayContext.cs
+++ b/src/VirtualDesktopNumber/UI/TrayContext.cs
@@ -1,4 +1,5 @@
-﻿using System.Resources;
+﻿using System.Diagnostics;
+using System.Resources;
 using VirtualDesktopNumber.Helpers;
 using WindowsDesktop;
 
@@ -17,9 +18,33 @@ public class TrayContext : ApplicationContext
             ContextMenuStrip = GetContextMenuStrip(),
             Visible = true
         };
+        trayIcon.MouseClick += OnTrayIconClicked;
 
         UpdateDesktopNumber(VirtualDesktop.Current);
         Application.Idle += ApplicationIdle;
+    }
+
+    private void OnTrayIconClicked(object? sender, MouseEventArgs e)
+    {
+        // Left click: show task view
+        if (e.Button == MouseButtons.Left)
+        {
+            ProcessStartInfo psi = new()
+            {
+                // ShellExecute'ing this magic GUID here opens Task View. No idea why,
+                // got the GUID from https://stackoverflow.com/a/62646513.
+                FileName = "shell:::{3080F90E-D7AD-11D9-BD98-0000947B0257}",
+                UseShellExecute = true,
+            };
+            Process.Start(psi);
+        }
+
+        // Right click: show context menu. This already happens automatically, but the position
+        // gets all borked. This puts it closer to where the mouse is.
+        if (e.Button == MouseButtons.Right)
+        {
+            trayIcon.ContextMenuStrip.Show(Cursor.Position.X, Cursor.Position.Y -  trayIcon.ContextMenuStrip.Height);
+        }
     }
 
     private void ApplicationIdle(object? sender, EventArgs e)


### PR DESCRIPTION
First off, thanks for making this! I love it, in no small part because the icons are very pretty and fit the rest very well.

I noticed that I now have two virtual-desktop-related buttons, which is a bit much: 
![image](https://github.com/esvres/vdn/assets/703546/27fa0080-b55c-495a-a57c-08b3da6934b7)

So I decided to try if I could make vdn open the Task View on left-click, so I could hide the Task View button from my taskbar without having to remember the Win+Tab keyboard shortcut. Given how related this is to the core function of the tool, I was thinking that maybe you'd be happy to merge that in. So 6GB of visual studio later, here we go, a PR!

I also fixed #4 while I was at it.